### PR TITLE
feat: design agentic quant research architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,91 @@
 # finance-rag-model1030
-financial rag model used for prediction of stocks
-Financial Recommendation System using RAG and CTA Strategy Backtesting
 
-This project implements a financial recommendation system using a Retrieval-Augmented Generation (RAG) model for the financial domain. The application is designed to provide real-time financial recommendations and includes a Commodity Trading Advisor (CTA) strategy backtesting module to validate trading strategies.
+综合量化投研平台，结合缠论思想、Agentic RAG 与多平台回测能力，支持大模型驱动的投研流程。
 
-Features
+## 架构总览
 
-	•	RAG-based Recommendations: Utilizes a pre-trained RAG model from HuggingFace to generate financial recommendations.
-	•	Data Retrieval: Retrieves and preprocesses stock data for strategy testing.
-	•	CTA Strategy Backtesting: Implements a simple moving average crossover strategy using the Backtrader framework.
-	•	API Endpoints: Includes a RESTful API for querying recommendations and triggering backtests.
- Project Structure
- 
- ├── data/                   # Folder containing financial data files
-├── models/                 # Folder for storing pre-trained or fine-tuned models
-├── scripts/
-│   ├── data_preprocessing.py  # Script for data collection and preprocessing
-│   ├── model_training.py      # Script for model fine-tuning and training
-│   ├── strategy_backtesting.py # Script for CTA strategy backtesting
-│   └── rag_inference.py       # Script for RAG model inference
-├── app.py                 # Main application script for API endpoints
-└── README.md              # Project documentation
+平台按照分层架构设计，覆盖从大模型接入到硬件适配的十个核心模块：
+
+1. **大模型接入层**（`quant_platform/llm`）：支持 OpenAI、Anthropic、DeepSeek、通义千问等主流模型，提供统一路由与降级策略。
+2. **Agentic RAG 层**（`quant_platform/rag`）：使用 BAAI 的 BGE 嵌入与 Reranker，结合余弦相似度与 BM25 混合检索，可接入 Qdrant 或回退至内存检索。
+3. **新知识拉取层**（`quant_platform/ingestion`）：对接雪球、A 股指数与金融机构研报，支持定时抓取并写入 RAG。
+4. **平台对接层**（`quant_platform/backtesting`）：封装缠论策略回测与三方平台适配器，可通过 token 提交回测任务。
+5. **研究层**（`quant_platform/research`）：自动论文检索 + 人工笔记并行管理，生成投研报告。
+6. **前端层**（`quant_platform/frontend`）：规划 React Shell + Vue 组件协同的登录页面蓝图。
+7. **Agent 能力对接层**（`quant_platform/agents`）：集成 UI-TARS 等 Agentics 助手能力注册表。
+8. **虚拟容器层**（`quant_platform/virtualization`）：模拟人工登录流程，统一管理需要人机验证的网站任务。
+9. **架构优化层**（`quant_platform/architecture_layer`）：聚合业内优秀框架，持续反思并输出设计模式建议。
+10. **底层调优适配层**（`quant_platform/hardware`）：根据不同硬件资源调整模型选择与批量参数。
+
+## 主要组件
+
+- `app.py`：Flask API，统一暴露推荐、回测、研究、Agent、虚拟登录等接口。
+- `quant_platform/`：核心 Python 包，囊括十个模块的实现。
+- `scripts/`：示例脚本，演示 RAG 推理、数据采集、缠论回测与架构自检流程。
+
+## 快速开始
+
+1. 安装依赖（根据实际需求选择）：
+   ```bash
+   pip install flask pandas requests sentence-transformers FlagEmbedding qdrant-client rank-bm25
+   ```
+2. 配置必要的环境变量（可选）：
+   ```bash
+   export OPENAI_API_KEY=...  # 或其他模型 token
+   export QDRANT_HOST=localhost
+   export QDRANT_PORT=6333
+   ```
+3. 启动 API：
+   ```bash
+   python app.py
+   ```
+4. 运行示例脚本：
+   ```bash
+   python scripts/rag_inference.py
+   python scripts/strategy_backtesting.py
+   python scripts/data_preprocessing.py
+   python scripts/model_training.py
+   ```
+
+## 接口示例
+
+- 推荐接口：
+  ```bash
+  curl -X POST http://localhost:5000/recommend \
+       -H "Content-Type: application/json" \
+       -d '{"query": "银行板块缠论策略怎么构建？", "rounds": 2}'
+  ```
+- 本地回测：
+  ```bash
+  curl -X POST http://localhost:5000/backtest/local \
+       -H "Content-Type: application/json" \
+       -d '{"market_data": [{"close": 100}, {"close": 101}, {"close": 99}]}'
+  ```
+
+## 目录结构
+
+```
+├── app.py
+├── quant_platform/
+│   ├── llm/ ...
+│   ├── rag/ ...
+│   ├── ingestion/ ...
+│   ├── backtesting/ ...
+│   ├── research/ ...
+│   ├── frontend/ ...
+│   ├── agents/ ...
+│   ├── virtualization/ ...
+│   ├── architecture_layer/ ...
+│   └── hardware/ ...
+└── scripts/
+    ├── rag_inference.py
+    ├── strategy_backtesting.py
+    ├── data_preprocessing.py
+    └── model_training.py
+```
+
+## 说明
+
+- 所有外部依赖均采用“尽力而为”策略：缺少 token 或第三方依赖时自动回退到 Dummy 实现，保证系统可用性。
+- 缠论策略示例为轻量化实现，可按需替换为生产级算法。
+- 可结合 AgentRegistry 与 VirtualLoginSandbox 扩展对复杂登录流程及人机验证的支持。

--- a/app.py
+++ b/app.py
@@ -1,19 +1,145 @@
-from flask import Flask, request, jsonify
-from rag_inference import generate_recommendation
-from strategy_backtesting import run_backtest
+"""Flask API exposing the layered quant research platform."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import pandas as pd
+from flask import Flask, jsonify, request
+
+from quant_platform import (
+    ArchitectureOptimiser,
+    AgenticRAGPipeline,
+    DataIngestionManager,
+    FrontendArchitecturePlanner,
+    HardwareAdapter,
+    PlatformConfig,
+    QuantBacktestManager,
+    ResearchCoordinator,
+    VirtualLoginSandbox,
+    create_client,
+)
+from quant_platform.agents import DEFAULT_AGENT_REGISTRY
+from quant_platform.llm import DummyLLMClient
 
 app = Flask(__name__)
 
-@app.route("/recommend", methods=["POST"])
-def recommend():
-    query = request.json.get("query")
-    recommendation = generate_recommendation(query)
-    return jsonify({"recommendation": recommendation})
+config = PlatformConfig()
+provider = os.getenv("LLM_PROVIDER", "openai")
+token = getattr(config.llm_tokens, provider, None)
+try:
+    llm_client = create_client(provider, token=token)
+    # If token missing the concrete client will raise when invoked.
+    # Replace with dummy proactively to keep API responsive.
+    if not token:
+        llm_client = DummyLLMClient(token=None)
+except Exception:  # pragma: no cover - fallback path
+    llm_client = DummyLLMClient(token=None)
 
-@app.route("/backtest", methods=["GET"])
-def backtest():
-    result = run_backtest()
-    return jsonify({"backtest_result": result})
+rag_pipeline = AgenticRAGPipeline(config=config, llm_client=llm_client)
+ingestion_manager = DataIngestionManager(config=config.data_sources, sink=rag_pipeline)
+backtest_manager = QuantBacktestManager(platform_config=config.backtest)
+research_coordinator = ResearchCoordinator()
+frontend_planner = FrontendArchitecturePlanner()
+virtual_sandbox = VirtualLoginSandbox()
+architecture_optimiser = ArchitectureOptimiser(frameworks=["FastAPI", "Ray", "Airflow"])
+hardware_adapter = HardwareAdapter(profile=config.hardware)
+
+
+@app.route("/recommend", methods=["POST"])
+def recommend() -> Any:
+    payload = request.get_json(force=True)
+    query = payload.get("query", "")
+    rounds = int(payload.get("rounds", 2))
+    top_k = int(payload.get("top_k", 5))
+    result = rag_pipeline.run(query=query, rounds=rounds, top_k=top_k)
+    return jsonify(result)
+
+
+@app.route("/ingest", methods=["POST"])
+def ingest() -> Any:
+    payload = request.get_json(force=True)
+    snowball = payload.get("snowball", [])
+    indices = payload.get("indices", [])
+    topics = payload.get("topics", [])
+    ingestion_manager.ingest_all(snowball, indices, topics)
+    return jsonify({"status": "ok"})
+
+
+@app.route("/backtest/local", methods=["POST"])
+def backtest_local() -> Any:
+    payload = request.get_json(force=True)
+    market_data = pd.DataFrame(payload.get("market_data", []))
+    result = backtest_manager.backtest_local(market_data)
+    return jsonify(result)
+
+
+@app.route("/backtest/remote", methods=["POST"])
+def backtest_remote() -> Any:
+    payload = request.get_json(force=True)
+    platform = payload["platform"]
+    strategy_code = payload["strategy_code"]
+    params = payload.get("params", {})
+    result = backtest_manager.submit_remote(platform, strategy_code, params)
+    return jsonify(result)
+
+
+@app.route("/research", methods=["POST"])
+def research() -> Any:
+    payload = request.get_json(force=True)
+    query = payload.get("query", "")
+    human_notes = payload.get("human_notes", [])
+    for note in human_notes:
+        research_coordinator.add_human_insight(note)
+    report = research_coordinator.compile_report(query)
+    return jsonify(report)
+
+
+@app.route("/frontend/login-blueprint", methods=["GET"])
+def frontend_blueprint() -> Any:
+    blueprint = frontend_planner.login_page_blueprint()
+    serialised = {
+        section: [module.__dict__ for module in modules]
+        for section, modules in blueprint.items()
+    }
+    return jsonify(serialised)
+
+
+@app.route("/agents", methods=["GET"])
+def list_agents() -> Any:
+    return jsonify(DEFAULT_AGENT_REGISTRY.list_agents())
+
+
+@app.route("/virtual/tasks", methods=["GET", "POST", "PUT"])
+def virtual_tasks() -> Any:
+    if request.method == "POST":
+        payload = request.get_json(force=True)
+        virtual_sandbox.enqueue(payload["url"], payload.get("instructions", ""))
+        return jsonify({"status": "queued"})
+    if request.method == "PUT":
+        payload = request.get_json(force=True)
+        virtual_sandbox.mark_completed(payload["url"])
+        return jsonify({"status": "completed"})
+    return jsonify(virtual_sandbox.list_pending())
+
+
+@app.route("/architecture/reflect", methods=["POST"])
+def architecture_reflect() -> Any:
+    payload = request.get_json(force=True)
+    goals = payload.get("goals", [])
+    reflection = architecture_optimiser.run_reflection(goals)
+    return jsonify(reflection.__dict__)
+
+
+@app.route("/hardware/profile", methods=["GET"])
+def hardware_profile() -> Any:
+    return jsonify(hardware_adapter.summary())
+
+
+@app.route("/health", methods=["GET"])
+def health() -> Any:
+    return jsonify({"status": "ok"})
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/quant_platform/__init__.py
+++ b/quant_platform/__init__.py
@@ -1,0 +1,26 @@
+"""Quant strategy platform package exposing layered architecture components."""
+from .config import PlatformConfig
+from .llm import create_client
+from .rag import AgenticRAGPipeline
+from .ingestion import DataIngestionManager
+from .backtesting import QuantBacktestManager
+from .research import ResearchCoordinator
+from .frontend import FrontendArchitecturePlanner
+from .agents import DEFAULT_AGENT_REGISTRY
+from .virtualization import VirtualLoginSandbox
+from .architecture_layer import ArchitectureOptimiser
+from .hardware import HardwareAdapter
+
+__all__ = [
+    "PlatformConfig",
+    "create_client",
+    "AgenticRAGPipeline",
+    "DataIngestionManager",
+    "QuantBacktestManager",
+    "ResearchCoordinator",
+    "FrontendArchitecturePlanner",
+    "DEFAULT_AGENT_REGISTRY",
+    "VirtualLoginSandbox",
+    "ArchitectureOptimiser",
+    "HardwareAdapter",
+]

--- a/quant_platform/agents/__init__.py
+++ b/quant_platform/agents/__init__.py
@@ -1,0 +1,4 @@
+"""Agent integration exports."""
+from .integration import AgentRegistry, AgentCapability, DEFAULT_AGENT_REGISTRY
+
+__all__ = ["AgentRegistry", "AgentCapability", "DEFAULT_AGENT_REGISTRY"]

--- a/quant_platform/agents/integration.py
+++ b/quant_platform/agents/integration.py
@@ -1,0 +1,49 @@
+"""Integration layer for agentic assistants (e.g. UI-TARS)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class AgentCapability:
+    name: str
+    description: str
+    endpoint: str
+
+
+@dataclass
+class AgentRegistry:
+    """Register agent assistants and expose their capabilities."""
+
+    agents: Dict[str, List[AgentCapability]]
+
+    def list_agents(self) -> Dict[str, List[str]]:
+        return {name: [cap.name for cap in capabilities] for name, capabilities in self.agents.items()}
+
+    def get_capability(self, agent_name: str, capability: str) -> AgentCapability:
+        for cap in self.agents.get(agent_name, []):
+            if cap.name == capability:
+                return cap
+        raise KeyError(f"Capability {capability} not found for agent {agent_name}")
+
+
+DEFAULT_AGENT_REGISTRY = AgentRegistry(
+    agents={
+        "ui-tars": [
+            AgentCapability(
+                name="browser_automation",
+                description="在受控浏览器中执行自动化操作，用于验证码、人机验证。",
+                endpoint="http://ui-tars/api/browser",
+            ),
+            AgentCapability(
+                name="form_filling",
+                description="指导用户完成复杂表单与风控提交流程。",
+                endpoint="http://ui-tars/api/forms",
+            ),
+        ],
+    }
+)
+
+
+__all__ = ["AgentRegistry", "AgentCapability", "DEFAULT_AGENT_REGISTRY"]

--- a/quant_platform/architecture_layer/__init__.py
+++ b/quant_platform/architecture_layer/__init__.py
@@ -1,0 +1,4 @@
+"""Architecture optimisation layer."""
+from .optimizer import ArchitectureOptimiser, ArchitectureReflection
+
+__all__ = ["ArchitectureOptimiser", "ArchitectureReflection"]

--- a/quant_platform/architecture_layer/optimizer.py
+++ b/quant_platform/architecture_layer/optimizer.py
@@ -1,0 +1,42 @@
+"""Architecture optimisation utilities for continuous improvement."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class ArchitectureReflection:
+    """Store reflection results and recommended actions."""
+
+    observations: List[str]
+    recommended_patterns: List[str]
+    integration_targets: List[str]
+
+
+@dataclass
+class ArchitectureOptimiser:
+    """Evaluate current system state and recommend improvements."""
+
+    frameworks: List[str]
+
+    def run_reflection(self, goals: List[str]) -> ArchitectureReflection:
+        observations = [f"目标 {goal} 与框架 {framework} 可结合" for goal in goals for framework in self.frameworks]
+        recommended_patterns = [
+            "Domain-Driven Design",
+            "Event Sourcing",
+            "Hexagonal Architecture",
+        ]
+        integration_targets = [
+            "FastAPI",
+            "Ray",
+            "Prefect",
+        ]
+        return ArchitectureReflection(
+            observations=observations,
+            recommended_patterns=recommended_patterns,
+            integration_targets=integration_targets,
+        )
+
+
+__all__ = ["ArchitectureOptimiser", "ArchitectureReflection"]

--- a/quant_platform/backtesting/__init__.py
+++ b/quant_platform/backtesting/__init__.py
@@ -1,0 +1,6 @@
+"""Backtesting layer for Chan-lun strategies and platform integrations."""
+from .manager import QuantBacktestManager
+from .chan import ChanLunAnalyzer, ChanSegment
+from .platforms import BacktestPlatformRegistry
+
+__all__ = ["QuantBacktestManager", "ChanLunAnalyzer", "ChanSegment", "BacktestPlatformRegistry"]

--- a/quant_platform/backtesting/chan.py
+++ b/quant_platform/backtesting/chan.py
@@ -1,0 +1,71 @@
+"""Simplified Chan theory utilities for quantitative strategies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import pandas as pd
+
+
+@dataclass
+class ChanSegment:
+    """Represent a Chan-lun segment (笔) with trend direction and extremum."""
+
+    start_index: int
+    end_index: int
+    direction: str  # "up" or "down"
+    high: float
+    low: float
+
+
+class ChanLunAnalyzer:
+    """Very lightweight Chan theory pattern detector."""
+
+    def __init__(self, window: int = 5) -> None:
+        self.window = window
+
+    def _detect_swings(self, price: pd.Series) -> List[int]:
+        """Detect swing points using rolling window extrema."""
+
+        highs = price.rolling(self.window, center=True).max()
+        lows = price.rolling(self.window, center=True).min()
+        swing_points: List[int] = []
+        for idx in range(self.window, len(price) - self.window):
+            if price.iloc[idx] == highs.iloc[idx] or price.iloc[idx] == lows.iloc[idx]:
+                swing_points.append(idx)
+        return swing_points
+
+    def extract_segments(self, data: pd.DataFrame) -> List[ChanSegment]:
+        """Extract Chan segments from OHLC data."""
+
+        close = data["close"]
+        swing_points = self._detect_swings(close)
+        segments: List[ChanSegment] = []
+        for start, end in zip(swing_points, swing_points[1:]):
+            segment_close = close.iloc[start:end + 1]
+            direction = "up" if segment_close.iloc[-1] > segment_close.iloc[0] else "down"
+            segments.append(
+                ChanSegment(
+                    start_index=start,
+                    end_index=end,
+                    direction=direction,
+                    high=float(segment_close.max()),
+                    low=float(segment_close.min()),
+                )
+            )
+        return segments
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        """Create trading signals based on Chan segments and moving averages."""
+
+        segments = self.extract_segments(data)
+        signal = pd.Series(0, index=data.index)
+        for segment in segments:
+            if segment.direction == "up":
+                signal.iloc[segment.end_index] = 1
+            else:
+                signal.iloc[segment.end_index] = -1
+        return signal.ffill().fillna(0)
+
+
+__all__ = ["ChanLunAnalyzer", "ChanSegment"]

--- a/quant_platform/backtesting/manager.py
+++ b/quant_platform/backtesting/manager.py
@@ -1,0 +1,47 @@
+"""Backtesting manager orchestrating Chan-lun strategies and platform integrations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+
+from ..config import BacktestPlatformConfig
+from .chan import ChanLunAnalyzer
+from .platforms import BacktestPlatformRegistry
+
+
+@dataclass
+class QuantBacktestManager:
+    """Coordinate local Chan-lun strategy evaluation and remote submissions."""
+
+    platform_config: BacktestPlatformConfig
+    analyzer: ChanLunAnalyzer = ChanLunAnalyzer()
+    registry: BacktestPlatformRegistry | None = None
+
+    def __post_init__(self) -> None:
+        if self.registry is None:
+            self.registry = BacktestPlatformRegistry.from_tokens(self.platform_config.platform_tokens)
+
+    def backtest_local(self, market_data: pd.DataFrame, initial_capital: float = 1_000_000.0) -> Dict[str, float]:
+        """Run a simple Chan-lun based backtest locally."""
+
+        signals = self.analyzer.generate_signals(market_data)
+        returns = market_data["close"].pct_change().fillna(0)
+        strategy_returns = returns * signals.shift(1).fillna(0)
+        equity_curve = (1 + strategy_returns).cumprod() * initial_capital
+        return {
+            "final_equity": float(equity_curve.iloc[-1]),
+            "cumulative_return": float(equity_curve.iloc[-1] / initial_capital - 1),
+            "max_drawdown": float((equity_curve.cummax() - equity_curve).max() / equity_curve.cummax().max()),
+        }
+
+    def submit_remote(self, platform: str, strategy_code: str, params: Optional[dict] = None) -> Dict[str, str]:
+        if params is None:
+            params = {}
+        if self.registry is None:
+            raise RuntimeError("Backtest platform registry not configured")
+        return self.registry.run(platform, strategy_code, params)
+
+
+__all__ = ["QuantBacktestManager"]

--- a/quant_platform/backtesting/platforms.py
+++ b/quant_platform/backtesting/platforms.py
@@ -1,0 +1,58 @@
+"""Adapters for third-party backtesting platforms."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Protocol
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BacktestPlatform(Protocol):
+    """Protocol representing a backtesting platform adapter."""
+
+    name: str
+
+    def run(self, strategy_code: str, params: dict) -> dict:
+        ...
+
+
+@dataclass
+class ExternalPlatformAdapter:
+    """Generic adapter that proxies to external platform APIs."""
+
+    name: str
+    token: str
+
+    def run(self, strategy_code: str, params: dict) -> dict:
+        if not self.token:
+            raise RuntimeError(f"Token for platform {self.name} missing")
+        LOGGER.info("Submitting backtest to %s with params %s", self.name, params)
+        # Placeholder: integration with vendor SDK/API would happen here.
+        return {"platform": self.name, "status": "submitted", "params": params}
+
+
+@dataclass
+class BacktestPlatformRegistry:
+    """Maintain a registry of available platform adapters."""
+
+    adapters: Dict[str, BacktestPlatform]
+
+    @classmethod
+    def from_tokens(cls, tokens: Dict[str, str]) -> "BacktestPlatformRegistry":
+        adapters = {
+            name: ExternalPlatformAdapter(name=name, token=token)
+            for name, token in tokens.items()
+            if token
+        }
+        return cls(adapters=adapters)
+
+    def run(self, platform: str, strategy_code: str, params: dict) -> dict:
+        adapter = self.adapters.get(platform)
+        if adapter is None:
+            raise KeyError(f"Platform {platform} not configured")
+        return adapter.run(strategy_code, params)
+
+
+__all__ = ["BacktestPlatformRegistry", "ExternalPlatformAdapter"]

--- a/quant_platform/config.py
+++ b/quant_platform/config.py
@@ -1,0 +1,86 @@
+"""Configuration utilities for the quant strategy platform."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+import os
+
+
+@dataclass
+class QdrantConfig:
+    """Configuration for Qdrant vector database."""
+
+    host: str = field(default_factory=lambda: os.getenv("QDRANT_HOST", "localhost"))
+    port: int = field(default_factory=lambda: int(os.getenv("QDRANT_PORT", "6333")))
+    api_key: Optional[str] = field(default_factory=lambda: os.getenv("QDRANT_API_KEY"))
+    collection_name: str = field(
+        default_factory=lambda: os.getenv("QDRANT_COLLECTION", "finance_rag_documents")
+    )
+
+
+@dataclass
+class LLMProviderTokens:
+    """Access tokens for supported LLM providers."""
+
+    openai: Optional[str] = field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    anthropic: Optional[str] = field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY"))
+    deepseek: Optional[str] = field(default_factory=lambda: os.getenv("DEEPSEEK_API_KEY"))
+    qwen: Optional[str] = field(default_factory=lambda: os.getenv("QWEN_API_KEY"))
+
+
+@dataclass
+class DataSourceConfig:
+    """Configuration for external financial data sources."""
+
+    snowball_cookie: Optional[str] = field(
+        default_factory=lambda: os.getenv("SNOWBALL_COOKIE")
+    )  # 雪球
+    research_api_token: Optional[str] = field(default_factory=lambda: os.getenv("RESEARCH_API_TOKEN"))
+    aws_secret_name: Optional[str] = field(default_factory=lambda: os.getenv("AWS_SECRET_NAME"))
+
+
+@dataclass
+class BacktestPlatformConfig:
+    """Tokens for accessing third-party backtesting services."""
+
+    platform_tokens: Dict[str, str] = field(
+        default_factory=lambda: {
+            "joinquant": os.getenv("JOINQUANT_TOKEN", ""),
+            "ricequant": os.getenv("RICEQUANT_TOKEN", ""),
+            "bigquant": os.getenv("BIGQUANT_TOKEN", ""),
+        }
+    )
+
+
+@dataclass
+class HardwareProfile:
+    """Hardware adaptation profile."""
+
+    accelerator: Optional[str] = field(default_factory=lambda: os.getenv("ACCELERATOR_TYPE"))
+    gpu_memory_gb: Optional[int] = field(
+        default_factory=lambda: int(os.getenv("GPU_MEMORY_GB", "0")) if os.getenv("GPU_MEMORY_GB") else None
+    )
+    cpu_cores: Optional[int] = field(
+        default_factory=lambda: int(os.getenv("CPU_CORES", "0")) if os.getenv("CPU_CORES") else None
+    )
+
+
+@dataclass
+class PlatformConfig:
+    """Master configuration object aggregating all subsystems."""
+
+    llm_tokens: LLMProviderTokens = field(default_factory=LLMProviderTokens)
+    qdrant: QdrantConfig = field(default_factory=QdrantConfig)
+    data_sources: DataSourceConfig = field(default_factory=DataSourceConfig)
+    backtest: BacktestPlatformConfig = field(default_factory=BacktestPlatformConfig)
+    hardware: HardwareProfile = field(default_factory=HardwareProfile)
+
+
+__all__ = [
+    "PlatformConfig",
+    "LLMProviderTokens",
+    "QdrantConfig",
+    "DataSourceConfig",
+    "BacktestPlatformConfig",
+    "HardwareProfile",
+]

--- a/quant_platform/frontend/__init__.py
+++ b/quant_platform/frontend/__init__.py
@@ -1,0 +1,4 @@
+"""Frontend planning tools."""
+from .architecture import FrontendArchitecturePlanner, FrontendModule
+
+__all__ = ["FrontendArchitecturePlanner", "FrontendModule"]

--- a/quant_platform/frontend/architecture.py
+++ b/quant_platform/frontend/architecture.py
@@ -1,0 +1,48 @@
+"""Frontend architecture blueprint combining React and Vue modules."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class FrontendModule:
+    name: str
+    framework: str
+    description: str
+
+
+@dataclass
+class FrontendArchitecturePlanner:
+    """Describe the hybrid React + Vue frontend layout."""
+
+    def login_page_blueprint(self) -> Dict[str, List[FrontendModule]]:
+        return {
+            "shell": [
+                FrontendModule(
+                    name="AuthShell",
+                    framework="React",
+                    description="负责全局状态、路由守卫和与后端的 token 交互。",
+                ),
+            ],
+            "widgets": [
+                FrontendModule(
+                    name="LoginForm",
+                    framework="Vue",
+                    description="使用 Composition API 构建的表单组件，支持验证码和多因素认证。",
+                ),
+                FrontendModule(
+                    name="ProviderSelector",
+                    framework="React",
+                    description="展示可选的大模型和回测平台，通过 context 共享选择状态。",
+                ),
+                FrontendModule(
+                    name="AgentStatusPanel",
+                    framework="Vue",
+                    description="实时展示 agent 任务进度，使用 WebSocket 获取状态更新。",
+                ),
+            ],
+        }
+
+
+__all__ = ["FrontendArchitecturePlanner", "FrontendModule"]

--- a/quant_platform/hardware/__init__.py
+++ b/quant_platform/hardware/__init__.py
@@ -1,0 +1,4 @@
+"""Hardware adaptation exports."""
+from .adapter import HardwareAdapter
+
+__all__ = ["HardwareAdapter"]

--- a/quant_platform/hardware/adapter.py
+++ b/quant_platform/hardware/adapter.py
@@ -1,0 +1,43 @@
+"""Hardware adaptation strategies for heterogeneous environments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from ..config import HardwareProfile
+
+
+@dataclass
+class HardwareAdapter:
+    """Select optimal model variants and batch sizes based on hardware."""
+
+    profile: HardwareProfile
+
+    def select_embedding_batch_size(self) -> int:
+        if self.profile.gpu_memory_gb and self.profile.gpu_memory_gb >= 24:
+            return 64
+        if self.profile.gpu_memory_gb and self.profile.gpu_memory_gb >= 12:
+            return 32
+        if self.profile.cpu_cores and self.profile.cpu_cores >= 16:
+            return 16
+        return 8
+
+    def choose_llm_model(self) -> str:
+        accelerator = (self.profile.accelerator or "cpu").lower()
+        if "h100" in accelerator or "a100" in accelerator:
+            return "gpt-4o"
+        if "v100" in accelerator or "l40" in accelerator:
+            return "gpt-4o-mini"
+        return "qwen-plus"
+
+    def summary(self) -> Dict[str, str | int | None]:
+        return {
+            "accelerator": self.profile.accelerator,
+            "gpu_memory_gb": self.profile.gpu_memory_gb,
+            "cpu_cores": self.profile.cpu_cores,
+            "embedding_batch_size": self.select_embedding_batch_size(),
+            "llm_model": self.choose_llm_model(),
+        }
+
+
+__all__ = ["HardwareAdapter"]

--- a/quant_platform/ingestion/__init__.py
+++ b/quant_platform/ingestion/__init__.py
@@ -1,0 +1,9 @@
+"""New knowledge ingestion layer."""
+from .sources import DataIngestionManager, SnowballSource, AShareIndexSource, ResearchReportSource
+
+__all__ = [
+    "DataIngestionManager",
+    "SnowballSource",
+    "AShareIndexSource",
+    "ResearchReportSource",
+]

--- a/quant_platform/ingestion/sources.py
+++ b/quant_platform/ingestion/sources.py
@@ -1,0 +1,131 @@
+"""Data acquisition layer for integrating new knowledge into the RAG store."""
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable, List, Protocol
+
+import json
+
+import requests
+
+from ..config import DataSourceConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DocumentSink(Protocol):
+    """Protocol representing objects capable of ingesting documents."""
+
+    def ingest(self, documents: Iterable[dict]) -> None:
+        ...
+
+
+@dataclass
+class SnowballSource:
+    """Retrieve latest posts from Snowball (雪球)."""
+
+    cookie: str | None
+
+    def fetch(self, symbol: str, limit: int = 20) -> List[dict]:
+        if not self.cookie:
+            LOGGER.warning("Snowball cookie missing; skipping fetch")
+            return []
+        url = "https://stock.xueqiu.com/v5/stock/chart/kline.json"
+        params = {"symbol": symbol, "begin": int(dt.datetime.utcnow().timestamp() * 1000), "period": "day"}
+        headers = {"Cookie": self.cookie, "User-Agent": "Mozilla/5.0"}
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            LOGGER.warning("Snowball fetch failed: %s", exc)
+            return []
+        data = resp.json().get("data", {})
+        items = data.get("items", [])[-limit:]
+        return [
+            {
+                "source": "snowball",
+                "symbol": symbol,
+                "timestamp": item[0],
+                "text": json.dumps(item, ensure_ascii=False),
+            }
+            for item in items
+        ]
+
+
+@dataclass
+class AShareIndexSource:
+    """Fetch A-share index snapshots."""
+
+    def fetch(self, symbols: Iterable[str]) -> List[dict]:
+        documents: List[dict] = []
+        for symbol in symbols:
+            doc = {
+                "source": "a-share-index",
+                "symbol": symbol,
+                "timestamp": int(dt.datetime.utcnow().timestamp()),
+                "text": f"指数 {symbol} 最新快照时间 {dt.datetime.utcnow().isoformat()}"
+            }
+            documents.append(doc)
+        return documents
+
+
+@dataclass
+class ResearchReportSource:
+    """Generic financial institution research report fetcher (placeholder)."""
+
+    api_token: str | None
+
+    def fetch(self, topic: str) -> List[dict]:
+        if not self.api_token:
+            LOGGER.warning("Research report API token missing")
+            return []
+        # Placeholder: in practice query vendor API
+        return [
+            {
+                "source": "research-report",
+                "topic": topic,
+                "timestamp": int(dt.datetime.utcnow().timestamp()),
+                "text": f"研究主题 {topic} 的最新研报摘要。",
+            }
+        ]
+
+
+@dataclass
+class DataIngestionManager:
+    """Coordinate ingestion tasks and push data into RAG."""
+
+    config: DataSourceConfig
+    sink: DocumentSink
+
+    def ingest_all(self, snowball_symbols: Iterable[str], index_symbols: Iterable[str], topics: Iterable[str]) -> None:
+        snowball = SnowballSource(cookie=self.config.snowball_cookie)
+        index_source = AShareIndexSource()
+        research_source = ResearchReportSource(api_token=self.config.research_api_token)
+
+        documents = []
+        for symbol in snowball_symbols:
+            documents.extend(snowball.fetch(symbol))
+        documents.extend(index_source.fetch(index_symbols))
+        for topic in topics:
+            documents.extend(research_source.fetch(topic))
+
+        if documents:
+            LOGGER.info("Ingested %d documents", len(documents))
+            self.sink.ingest(documents)
+
+    async def ingest_periodically(
+        self,
+        snowball_symbols: Iterable[str],
+        index_symbols: Iterable[str],
+        topics: Iterable[str],
+        interval_minutes: int = 30,
+    ) -> None:
+        while True:
+            self.ingest_all(snowball_symbols, index_symbols, topics)
+            await asyncio.sleep(interval_minutes * 60)
+
+
+__all__ = ["DataIngestionManager", "SnowballSource", "AShareIndexSource", "ResearchReportSource"]

--- a/quant_platform/llm/__init__.py
+++ b/quant_platform/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM integration layer exposing provider selection helpers."""
+from .router import create_client, PROVIDERS
+from .base import BaseLLMClient, DummyLLMClient
+
+__all__ = ["create_client", "PROVIDERS", "BaseLLMClient", "DummyLLMClient"]

--- a/quant_platform/llm/base.py
+++ b/quant_platform/llm/base.py
@@ -1,0 +1,38 @@
+"""Base abstractions for LLM provider integrations."""
+from __future__ import annotations
+
+import abc
+from typing import Any, Dict, Optional
+
+
+class BaseLLMClient(abc.ABC):
+    """Abstract base class defining the minimal LLM interface."""
+
+    model: Optional[str] = None
+
+    def __init__(self, token: Optional[str], model: Optional[str] = None) -> None:
+        self.token = token
+        if model is not None:
+            self.model = model
+
+    @abc.abstractmethod
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Generate text for the given ``prompt`` using provider specific APIs."""
+
+
+class DummyLLMClient(BaseLLMClient):
+    """Fallback client used when provider credentials are unavailable."""
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        suffix = kwargs.get("suffix", "")
+        return f"[dummy-response]{prompt}{suffix}"[:512]
+
+
+def ensure_token_available(token: Optional[str], provider_name: str) -> None:
+    """Raise a helpful error when the provider token is missing."""
+
+    if not token:
+        raise RuntimeError(
+            f"Missing token for provider '{provider_name}'. Set the environment variable or "
+            "update :class:`PlatformConfig`."
+        )

--- a/quant_platform/llm/clients.py
+++ b/quant_platform/llm/clients.py
@@ -1,0 +1,126 @@
+"""Provider specific LLM client implementations."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import json
+import logging
+
+import requests
+
+from .base import BaseLLMClient, DummyLLMClient, ensure_token_available
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OpenAIClient(BaseLLMClient):
+    """Wrapper around the OpenAI completion API."""
+
+    model = "gpt-4o-mini"
+    api_base = "https://api.openai.com/v1/chat/completions"
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        ensure_token_available(self.token, "openai")
+        headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+        payload = {
+            "model": kwargs.get("model", self.model),
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": kwargs.get("temperature", 0.2),
+        }
+        try:
+            response = requests.post(self.api_base, headers=headers, data=json.dumps(payload), timeout=60)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network path
+            LOGGER.warning("OpenAI request failed: %s", exc)
+            return DummyLLMClient(token=None).generate(prompt)
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+
+
+class AnthropicClient(BaseLLMClient):
+    """Wrapper for Anthropic's Claude completion API."""
+
+    model = "claude-3-sonnet-20240229"
+    api_base = "https://api.anthropic.com/v1/messages"
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        ensure_token_available(self.token, "anthropic")
+        headers = {
+            "x-api-key": self.token or "",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        payload = {
+            "model": kwargs.get("model", self.model),
+            "max_tokens": kwargs.get("max_tokens", 1024),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        try:
+            response = requests.post(self.api_base, headers=headers, data=json.dumps(payload), timeout=60)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network path
+            LOGGER.warning("Anthropic request failed: %s", exc)
+            return DummyLLMClient(token=None).generate(prompt)
+        data = response.json()
+        return data.get("content", [{}])[0].get("text", "")
+
+
+class DeepSeekClient(BaseLLMClient):
+    """Client for DeepSeek's completion endpoint."""
+
+    model = "deepseek-chat"
+    api_base = "https://api.deepseek.com/chat/completions"
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        ensure_token_available(self.token, "deepseek")
+        headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+        payload = {
+            "model": kwargs.get("model", self.model),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        try:
+            response = requests.post(self.api_base, headers=headers, data=json.dumps(payload), timeout=60)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover
+            LOGGER.warning("DeepSeek request failed: %s", exc)
+            return DummyLLMClient(token=None).generate(prompt)
+        data = response.json()
+        return data["choices"][0]["message"]["content"]
+
+
+class QwenClient(BaseLLMClient):
+    """Tongyi Qianwen client."""
+
+    model = "qwen-plus"
+    api_base = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:  # type: ignore[override]
+        ensure_token_available(self.token, "qwen")
+        headers = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+        payload = {
+            "model": kwargs.get("model", self.model),
+            "input": {
+                "messages": [
+                    {"role": "system", "content": kwargs.get("system", "You are a helpful assistant.")},
+                    {"role": "user", "content": prompt},
+                ]
+            },
+        }
+        try:
+            response = requests.post(self.api_base, headers=headers, data=json.dumps(payload), timeout=60)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover
+            LOGGER.warning("Qwen request failed: %s", exc)
+            return DummyLLMClient(token=None).generate(prompt)
+        data = response.json()
+        output = data.get("output", {})
+        return output.get("text", "") or DummyLLMClient(token=None).generate(prompt)
+
+
+__all__ = [
+    "OpenAIClient",
+    "AnthropicClient",
+    "DeepSeekClient",
+    "QwenClient",
+    "DummyLLMClient",
+]

--- a/quant_platform/llm/router.py
+++ b/quant_platform/llm/router.py
@@ -1,0 +1,27 @@
+"""Routing utilities to dynamically select LLM providers."""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import BaseLLMClient, DummyLLMClient
+from .clients import AnthropicClient, DeepSeekClient, OpenAIClient, QwenClient
+
+PROVIDERS: Dict[str, Type[BaseLLMClient]] = {
+    "openai": OpenAIClient,
+    "anthropic": AnthropicClient,
+    "deepseek": DeepSeekClient,
+    "qwen": QwenClient,
+}
+
+
+def create_client(provider: str, token: str | None = None, model: str | None = None) -> BaseLLMClient:
+    """Create a provider specific client."""
+
+    provider = provider.lower()
+    client_cls = PROVIDERS.get(provider)
+    if client_cls is None:
+        return DummyLLMClient(token=token, model=model)
+    return client_cls(token=token, model=model)
+
+
+__all__ = ["create_client", "PROVIDERS"]

--- a/quant_platform/rag/__init__.py
+++ b/quant_platform/rag/__init__.py
@@ -1,0 +1,12 @@
+"""RAG layer exports."""
+from .agentic import AgenticRAGPipeline
+from .retriever import EmbeddingService, HybridRetriever, RerankerService
+from .vector_store import QdrantVectorStore
+
+__all__ = [
+    "AgenticRAGPipeline",
+    "EmbeddingService",
+    "HybridRetriever",
+    "RerankerService",
+    "QdrantVectorStore",
+]

--- a/quant_platform/rag/agentic.py
+++ b/quant_platform/rag/agentic.py
@@ -1,0 +1,126 @@
+"""Agentic RAG pipeline with iterative summarisation and research."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+import logging
+
+from ..config import PlatformConfig
+from ..llm import BaseLLMClient
+from .retriever import EmbeddingService, HybridRetriever, RerankerService
+from .vector_store import QdrantVectorStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class _InMemoryRetriever:
+    """Fallback retriever used when external dependencies are unavailable."""
+
+    documents: List[dict] = field(default_factory=list)
+
+    def index(self, documents: Iterable[dict]) -> None:
+        for doc in documents:
+            if doc.get("text"):
+                self.documents.append(doc)
+
+    def retrieve(self, query: str, top_k: int = 5) -> List[dict]:  # noqa: D401 - simple wrapper
+        return self.documents[:top_k]
+
+
+class AgenticRAGPipeline:
+    """High level agent orchestrating retrieval and synthesis."""
+
+    config: PlatformConfig
+    llm_client: BaseLLMClient
+    retriever: HybridRetriever | _InMemoryRetriever | None = None
+    _conversation_summary: List[str] = field(default_factory=list, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.retriever is None:
+            try:
+                embedding_service = EmbeddingService()
+                reranker = RerankerService()
+                vector_store = QdrantVectorStore(
+                    host=self.config.qdrant.host,
+                    port=self.config.qdrant.port,
+                    api_key=self.config.qdrant.api_key,
+                    collection_name=self.config.qdrant.collection_name,
+                )
+                self.retriever = HybridRetriever(
+                    vector_store=vector_store, embedding_service=embedding_service, reranker=reranker
+                )
+            except Exception as exc:  # pragma: no cover - dependency missing path
+                LOGGER.warning("Falling back to in-memory retriever: %s", exc)
+                self.retriever = _InMemoryRetriever()
+
+    def ingest(self, documents: Iterable[dict]) -> None:
+        """Index new documents into the hybrid retriever."""
+
+        if self.retriever is None:
+            self.retriever = _InMemoryRetriever()
+        try:
+            self.retriever.index(documents)
+        except Exception as exc:  # pragma: no cover - dependency missing path
+            LOGGER.warning("Hybrid retriever ingest failed, switching to in-memory store: %s", exc)
+            fallback = _InMemoryRetriever()
+            fallback.index(documents)
+            self.retriever = fallback
+
+    def _iterate_summary(self, query: str, retrieved: List[dict]) -> str:
+        """Iteratively summarise retrieved content guided by the LLM agent."""
+
+        summary_prompt = """
+你是一名量化投研助手，需要结合缠论与量化策略思想对下面材料进行总结。
+重点提取：
+1. 核心观点和市场结构（缠论中趋势、盘整、买卖点）。
+2. 对量化策略可操作的指标或因子。
+3. 潜在的风险提示与回测假设。
+输出以要点形式列出。
+材料：{context}
+问题：{query}
+"""
+        context = "\n\n".join(doc.get("text", "") for doc in retrieved)
+        prompt = summary_prompt.format(context=context, query=query)
+        summary = self.llm_client.generate(prompt)
+        self._conversation_summary.append(summary)
+        return summary
+
+    def _research_iteration(self, query: str, iteration: int) -> str:
+        """Ask the agent to propose further research directions."""
+
+        exploration_prompt = f"""
+基于已有摘要：{self._conversation_summary[-1] if self._conversation_summary else '无'}
+第 {iteration} 轮研究，请列出需要补充的数据点、可能的回测参数和与缠论结构相关的验证步骤。
+"""
+        return self.llm_client.generate(exploration_prompt)
+
+    def run(self, query: str, rounds: int = 2, top_k: int = 5) -> dict:
+        """Execute the agentic RAG loop."""
+
+        if self.retriever is None:
+            return {"answer": "未检索到有效信息", "research": []}
+        try:
+            retrieved = self.retriever.retrieve(query, top_k=top_k)
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Retrieval failed, returning empty result: %s", exc)
+            retrieved = []
+        if not retrieved:
+            return {"answer": "未检索到有效信息", "research": []}
+        summary = self._iterate_summary(query, retrieved)
+        research_plan = []
+        for idx in range(rounds):
+            research_plan.append(self._research_iteration(query, idx + 1))
+        answer_prompt = f"""
+请基于总结与研究计划，给出针对问题《{query}》的量化建议，
+包括：
+- 缠论结构判断与趋势级别
+- 推荐的量化因子与参数
+- 需要补充的外部数据
+- 建议的风险控制与回测平台
+"""
+        answer = self.llm_client.generate(answer_prompt)
+        return {"answer": answer, "summary": summary, "research": research_plan, "sources": retrieved}
+
+
+__all__ = ["AgenticRAGPipeline"]

--- a/quant_platform/rag/retriever.py
+++ b/quant_platform/rag/retriever.py
@@ -1,0 +1,133 @@
+"""Hybrid retriever combining dense and sparse search with reranking."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List, Sequence
+import logging
+
+try:  # pragma: no cover - optional heavy deps
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover
+    SentenceTransformer = None  # type: ignore
+
+try:  # pragma: no cover
+    from rank_bm25 import BM25Okapi
+except Exception:  # pragma: no cover
+    BM25Okapi = None  # type: ignore
+
+try:  # pragma: no cover
+    from FlagEmbedding import FlagReranker
+except Exception:  # pragma: no cover
+    FlagReranker = None  # type: ignore
+
+from .vector_store import QdrantVectorStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class EmbeddingService:
+    """Wrapper around BAAI embedding models."""
+
+    model_name: str = "BAAI/bge-large-zh"
+    device: str | None = None
+    _model: SentenceTransformer | None = field(default=None, init=False, repr=False)
+
+    def _ensure_model(self) -> SentenceTransformer:
+        if SentenceTransformer is None:  # pragma: no cover - import guard
+            raise ImportError("sentence-transformers is required for EmbeddingService")
+        if self._model is None:
+            LOGGER.info("Loading embedding model: %s", self.model_name)
+            self._model = SentenceTransformer(self.model_name, device=self.device)
+        return self._model
+
+    def encode(self, texts: Sequence[str]) -> List[List[float]]:
+        model = self._ensure_model()
+        return model.encode(list(texts), convert_to_numpy=True).tolist()
+
+
+@dataclass
+class RerankerService:
+    """Wrap the BAAI reranker model."""
+
+    model_name: str = "BAAI/bge-reranker-large"
+    device: str | None = None
+    _model: FlagReranker | None = field(default=None, init=False, repr=False)
+
+    def _ensure_model(self) -> FlagReranker:
+        if FlagReranker is None:  # pragma: no cover
+            raise ImportError("FlagEmbedding is required for RerankerService")
+        if self._model is None:
+            LOGGER.info("Loading reranker model: %s", self.model_name)
+            self._model = FlagReranker(self.model_name, use_fp16=self.device == "cuda")
+        return self._model
+
+    def rerank(self, query: str, documents: Sequence[str], top_k: int = 5) -> List[int]:
+        model = self._ensure_model()
+        scores = model.compute_score([[query, doc] for doc in documents])
+        ranked_indices = sorted(range(len(documents)), key=lambda i: scores[i], reverse=True)
+        return ranked_indices[:top_k]
+
+
+@dataclass
+class HybridRetriever:
+    """Combine dense embedding similarity with BM25 sparse search."""
+
+    vector_store: QdrantVectorStore
+    embedding_service: EmbeddingService
+    reranker: RerankerService | None = None
+    bm25_tokenizer: Callable[[str], Sequence[str]] | None = None
+    _bm25: BM25Okapi | None = field(default=None, init=False, repr=False)
+    _documents: List[str] = field(default_factory=list, init=False, repr=False)
+
+    def index(self, documents: Iterable[dict]) -> None:
+        """Index documents in the vector store and prepare BM25 corpus."""
+
+        texts = []
+        payloads = []
+        for doc in documents:
+            text = doc.get("text")
+            if not text:
+                continue
+            texts.append(text)
+            payloads.append(doc)
+        if not texts:
+            return
+        embeddings = self.embedding_service.encode(texts)
+        self.vector_store.ensure_collection(vector_size=len(embeddings[0]))
+        self.vector_store.upsert(embeddings, payloads)
+
+        tokenizer = self.bm25_tokenizer or (lambda x: x.split())
+        tokenized = [tokenizer(text) for text in texts]
+        if BM25Okapi is None:  # pragma: no cover
+            LOGGER.warning("rank_bm25 is not installed; BM25 retrieval disabled")
+        else:
+            self._bm25 = BM25Okapi(tokenized)
+            self._documents = texts
+
+    def retrieve(self, query: str, top_k: int = 5) -> List[dict]:
+        """Retrieve documents using a hybrid search strategy."""
+
+        dense_embedding = self.embedding_service.encode([query])[0]
+        dense_results = self.vector_store.search(dense_embedding, limit=top_k * 2)
+
+        sparse_results: List[dict] = []
+        if self._bm25 is not None:
+            scores = self._bm25.get_scores((self.bm25_tokenizer or (lambda x: x.split()))(query))
+            ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[: top_k * 2]
+            sparse_results = [
+                {"text": self._documents[idx], "source": "bm25", "score": float(scores[idx])}
+                for idx in ranked
+            ]
+
+        combined = dense_results + sparse_results
+        if not combined:
+            return []
+
+        if self.reranker is not None:
+            rerank_indices = self.reranker.rerank(query, [doc["text"] for doc in combined], top_k=top_k)
+            return [combined[idx] for idx in rerank_indices]
+        return combined[:top_k]
+
+
+__all__ = ["HybridRetriever", "EmbeddingService", "RerankerService"]

--- a/quant_platform/rag/vector_store.py
+++ b/quant_platform/rag/vector_store.py
@@ -1,0 +1,54 @@
+"""Qdrant vector store wrapper used by the RAG subsystem."""
+from __future__ import annotations
+
+import logging
+from typing import List, Sequence
+
+try:  # pragma: no cover - optional dependency
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import Distance, VectorParams, PointStruct
+except Exception:  # pragma: no cover - fallback
+    QdrantClient = None  # type: ignore
+    Distance = VectorParams = PointStruct = object  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class QdrantVectorStore:
+    """Utility class encapsulating qdrant operations."""
+
+    def __init__(self, host: str, port: int, collection_name: str, api_key: str | None = None) -> None:
+        if QdrantClient is None:
+            raise ImportError("qdrant-client is required for QdrantVectorStore")
+        self.collection_name = collection_name
+        self.client = QdrantClient(host=host, port=port, api_key=api_key)
+
+    def ensure_collection(self, vector_size: int) -> None:
+        """Create the collection if it does not exist."""
+
+        try:
+            self.client.get_collection(self.collection_name)
+        except Exception:  # pragma: no cover - remote call
+            LOGGER.info("Creating Qdrant collection: %s", self.collection_name)
+            self.client.recreate_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+            )
+
+    def upsert(self, embeddings: Sequence[Sequence[float]], payloads: Sequence[dict]) -> None:
+        """Insert vectors into the collection."""
+
+        points = [
+            PointStruct(id=idx, vector=vector, payload=payload)
+            for idx, (vector, payload) in enumerate(zip(embeddings, payloads))
+        ]
+        self.client.upsert(collection_name=self.collection_name, points=points)
+
+    def search(self, embedding: Sequence[float], limit: int = 5) -> List[dict]:
+        """Search for similar vectors and return payloads."""
+
+        result = self.client.search(collection_name=self.collection_name, query_vector=embedding, limit=limit)
+        return [hit.payload for hit in result]
+
+
+__all__ = ["QdrantVectorStore"]

--- a/quant_platform/research/__init__.py
+++ b/quant_platform/research/__init__.py
@@ -1,0 +1,4 @@
+"""Research layer exports."""
+from .pipeline import ResearchCoordinator, DummyPaperSearchTool
+
+__all__ = ["ResearchCoordinator", "DummyPaperSearchTool"]

--- a/quant_platform/research/pipeline.py
+++ b/quant_platform/research/pipeline.py
@@ -1,0 +1,50 @@
+"""Research orchestration combining automated and human-in-the-loop analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Protocol
+
+
+class ResearchTool(Protocol):
+    """Protocol for research tooling (e.g. paper search APIs)."""
+
+    def search(self, query: str) -> List[dict]:
+        ...
+
+
+@dataclass
+class DummyPaperSearchTool:
+    """Placeholder tool returning canned results."""
+
+    def search(self, query: str) -> List[dict]:  # type: ignore[override]
+        return [
+            {"title": "Chan Theory in Quantitative Trading", "summary": "讨论缠论与量化策略结合的研究。"},
+            {"title": "Agentic RAG for Finance", "summary": "介绍金融场景的检索增强生成系统。"},
+        ]
+
+
+@dataclass
+class ResearchCoordinator:
+    """Coordinate automated research tasks and capture human notes."""
+
+    tools: Iterable[ResearchTool] = field(default_factory=lambda: [DummyPaperSearchTool()])
+    human_notes: List[str] = field(default_factory=list)
+
+    def run_auto_research(self, query: str) -> List[dict]:
+        results: List[dict] = []
+        for tool in self.tools:
+            results.extend(tool.search(query))
+        return results
+
+    def add_human_insight(self, note: str) -> None:
+        self.human_notes.append(note)
+
+    def compile_report(self, query: str) -> dict:
+        return {
+            "query": query,
+            "auto_research": self.run_auto_research(query),
+            "human_notes": list(self.human_notes),
+        }
+
+
+__all__ = ["ResearchCoordinator", "DummyPaperSearchTool"]

--- a/quant_platform/virtualization/__init__.py
+++ b/quant_platform/virtualization/__init__.py
@@ -1,0 +1,4 @@
+"""Virtual container layer exports."""
+from .sandbox import VirtualLoginSandbox, LoginTask
+
+__all__ = ["VirtualLoginSandbox", "LoginTask"]

--- a/quant_platform/virtualization/sandbox.py
+++ b/quant_platform/virtualization/sandbox.py
@@ -1,0 +1,39 @@
+"""Virtual container sandbox for handling manual login workflows."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class LoginTask:
+    url: str
+    instructions: str
+    completed: bool = False
+
+
+@dataclass
+class VirtualLoginSandbox:
+    """Maintain simulated browser sessions requiring human interaction."""
+
+    tasks: List[LoginTask] = field(default_factory=list)
+
+    def enqueue(self, url: str, instructions: str) -> None:
+        self.tasks.append(LoginTask(url=url, instructions=instructions))
+
+    def list_pending(self) -> List[Dict[str, str]]:
+        return [
+            {"url": task.url, "instructions": task.instructions}
+            for task in self.tasks
+            if not task.completed
+        ]
+
+    def mark_completed(self, url: str) -> None:
+        for task in self.tasks:
+            if task.url == url:
+                task.completed = True
+                return
+        raise KeyError(f"Task for {url} not found")
+
+
+__all__ = ["VirtualLoginSandbox", "LoginTask"]

--- a/scripts/data_preprocessing.py
+++ b/scripts/data_preprocessing.py
@@ -1,10 +1,35 @@
-import yfinance as yf
-import pandas as pd
+"""Data preprocessing helpers for feeding the RAG knowledge base."""
+from __future__ import annotations
 
-def download_stock_data(ticker, start, end):
-    data = yf.download(ticker, start=start, end=end)
-    data.to_csv(f'data/{ticker}.csv')
-    return data
+import json
+from pathlib import Path
 
-# 示例：下载Apple股票数据
-download_stock_data("AAPL", "2021-01-01", "2022-01-01")
+from quant_platform import DataIngestionManager, PlatformConfig
+
+OUTPUT_DIR = Path("data")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+class FileSink:
+    """Simple sink storing ingested documents locally."""
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+
+    def ingest(self, documents: list[dict]) -> None:
+        path = OUTPUT_DIR / self.filename
+        path.write_text(
+            "\n".join(json.dumps(doc, ensure_ascii=False) for doc in documents),
+            encoding="utf-8",
+        )
+        print(f"Exported {len(documents)} documents to {path}")
+
+
+def main() -> None:
+    config = PlatformConfig()
+    ingestion = DataIngestionManager(config=config.data_sources, sink=FileSink("ingested.jsonl"))
+    ingestion.ingest_all(["SH000001"], ["SH000300"], ["宏观策略"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_training.py
+++ b/scripts/model_training.py
@@ -1,11 +1,24 @@
-from transformers import RagTokenizer, RagRetriever, RagSequenceForGeneration
+"""Utility script to bootstrap the layered quant research stack."""
+from __future__ import annotations
 
-# 初始化模型和检索器
-tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
-retriever = RagRetriever.from_pretrained("facebook/rag-sequence-nq", index_name="custom")
-model = RagSequenceForGeneration.from_pretrained("facebook/rag-sequence-nq", retriever=retriever)
+from quant_platform import (
+    ArchitectureOptimiser,
+    HardwareAdapter,
+    PlatformConfig,
+    ResearchCoordinator,
+)
 
-def generate_recommendation(query):
-    inputs = tokenizer(query, return_tensors="pt")
-    output = model.generate(**inputs)
-    return tokenizer.batch_decode(output, skip_special_tokens=True)
+
+def main() -> None:
+    config = PlatformConfig()
+    hardware = HardwareAdapter(config.hardware)
+    optimiser = ArchitectureOptimiser(frameworks=["FastAPI", "Prefect", "Ray"])
+    research = ResearchCoordinator()
+
+    print("Hardware profile:", hardware.summary())
+    print("Architecture reflection:", optimiser.run_reflection(["高频回测", "多模态研究"]).__dict__)
+    print("Research preview:", research.run_auto_research("Chan theory"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag_inference.py
+++ b/scripts/rag_inference.py
@@ -1,34 +1,43 @@
-from transformers import RagTokenizer, RagRetriever, RagSequenceForGeneration
-import torch
+"""Command line helper to run the agentic RAG pipeline."""
+from __future__ import annotations
 
-# 初始化RAG模型、检索器和分词器
-tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
-retriever = RagRetriever.from_pretrained("facebook/rag-sequence-nq", index_name="custom")
-model = RagSequenceForGeneration.from_pretrained("facebook/rag-sequence-nq", retriever=retriever)
+import os
 
-# 设置设备（如果有GPU，则使用CUDA）
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-model.to(device)
+from quant_platform import AgenticRAGPipeline, PlatformConfig, create_client
+from quant_platform.llm import DummyLLMClient
 
-def generate_recommendation(query):
-    """
-    基于用户查询生成金融推荐
-    参数：
-        query (str): 用户查询文本
-    返回：
-        recommendation (str): 生成的推荐结果
-    """
-    # 对输入查询进行编码
-    inputs = tokenizer(query, return_tensors="pt").to(device)
+SAMPLE_DOCS = [
+    {
+        "source": "internal-note",
+        "text": "上证指数在30分钟级别形成三笔向上，关注前高压力位。",
+    },
+    {
+        "source": "strategy",
+        "text": "结合缠论中枢震荡，建议在中枢上沿进行分批减仓，使用5日均线作为辅助。",
+    },
+]
 
-    # 使用模型生成推荐文本
-    output_ids = model.generate(**inputs)
-    recommendation = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
 
-    return recommendation[0]
+def build_pipeline() -> AgenticRAGPipeline:
+    config = PlatformConfig()
+    provider = os.getenv("LLM_PROVIDER", "openai")
+    token = getattr(config.llm_tokens, provider, None)
+    try:
+        llm = create_client(provider, token=token)
+        if not token:
+            llm = DummyLLMClient(token=None)
+    except Exception:
+        llm = DummyLLMClient(token=None)
+    pipeline = AgenticRAGPipeline(config=config, llm_client=llm)
+    pipeline.ingest(SAMPLE_DOCS)
+    return pipeline
+
+
+def main() -> None:
+    pipeline = build_pipeline()
+    result = pipeline.run("如何基于缠论构建趋势追踪策略？", rounds=1)
+    print(result["answer"])
+
 
 if __name__ == "__main__":
-    # 测试生成推荐
-    query = "What are the latest trends in the stock market?"
-    recommendation = generate_recommendation(query)
-    print("Generated Recommendation:", recommendation)
+    main()

--- a/scripts/strategy_backtesting.py
+++ b/scripts/strategy_backtesting.py
@@ -1,22 +1,25 @@
-import backtrader as bt
+"""CLI utility demonstrating the Chan-lun backtest manager."""
+from __future__ import annotations
 
-class MovingAverageStrategy(bt.Strategy):
-    def __init__(self):
-        self.sma1 = bt.ind.SMA(period=10)
-        self.sma2 = bt.ind.SMA(period=20)
+import pandas as pd
 
-    def next(self):
-        if self.sma1 > self.sma2:
-            self.buy()
-        elif self.sma1 < self.sma2:
-            self.sell()
+from quant_platform import PlatformConfig
+from quant_platform.backtesting import QuantBacktestManager
 
-def run_backtest():
-    cerebro = bt.Cerebro()
-    data = bt.feeds.YahooFinanceCSVData(dataname="data/AAPL.csv")
-    cerebro.adddata(data)
-    cerebro.addstrategy(MovingAverageStrategy)
-    cerebro.run()
-    cerebro.plot()
 
-run_backtest()
+def load_sample_data() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=60, freq="D")
+    prices = pd.Series(range(60), index=dates).rolling(3).mean().fillna(method="bfill") + 100
+    return pd.DataFrame({"close": prices}, index=dates)
+
+
+def main() -> None:
+    config = PlatformConfig()
+    manager = QuantBacktestManager(platform_config=config.backtest)
+    data = load_sample_data()
+    report = manager.backtest_local(data)
+    print("Backtest report:", report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a new `quant_platform` package that covers LLM adapters, agentic RAG with fallbacks, data ingestion, Chan-lun backtesting, research tooling, frontend blueprinting, agent registry, virtualization, architecture optimisation, and hardware adaptation layers
- expose REST endpoints in `app.py` for recommendation, ingestion, backtesting, research, agent listings, virtual login handling, architecture reflection, and hardware profiles
- refresh the README and helper scripts to document and demonstrate the layered platform

## Testing
- python -m compileall .
- python -m compileall quant_platform/rag/agentic.py

------
https://chatgpt.com/codex/tasks/task_e_68cfac94588c8333acf4496bbbe4a76a